### PR TITLE
Update versions. Use aria2c instead of parallel

### DIFF
--- a/build-elf.sh
+++ b/build-elf.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export BINUTILSVER=2.31
 export BINUTILSREV=
-export GCCVER=8.2.0
+export GCCVER=9.1.0
 export GCCREV=
 export NEWLIBVER=3.0.0
 export NEWLIBREV=
 export MPCVER=1.1.0
 export MPCREV=
-export MPFRVER=3.1.6
+export MPFRVER=4.0.2
 export MPFRREV=
 export GMPVER=6.1.2
 export GMPREV=
@@ -17,9 +17,9 @@ export OBJFORMAT=ELF
 export TARGETMACH=sh-elf
 
 if [ -z ${PROGRAM_PREFIX} ]; then
-	export PROGRAM_PREFIX=saturn-sh2-elf-
+    export PROGRAM_PREFIX=saturn-sh2-elf-
 else
-	export PROGRAM_PREFIX=${PROGRAM_PREFIX}elf-
+    export PROGRAM_PREFIX=${PROGRAM_PREFIX}elf-
 fi
 
 export BINUTILS_CFLAGS="-s"
@@ -29,10 +29,10 @@ export GCC_FINAL_FLAGS="--with-cpu=m2 --with-sysroot=$SYSROOTDIR"
 ./build.sh
 
 if [ $? -ne 0 ]; then
-	echo "Failed to build the ELF toolchain"
-	exit 1
+    echo "Failed to build the ELF toolchain"
+    exit 1
 fi
 
 if [[ "${CREATEINSTALLER}" == "YES" ]]; then
-	./createinstaller.sh
+    ./createinstaller.sh
 fi

--- a/download.sh
+++ b/download.sh
@@ -1,70 +1,70 @@
 #!/bin/bash
 if [ ! -d $DOWNLOADDIR ]; then
-	mkdir -p $DOWNLOADDIR
+    mkdir -p $DOWNLOADDIR
 fi
 
 cd $DOWNLOADDIR
 
 if test "`curl -V`"; then
-	FETCH="curl -f -L -O -C -"
+    FETCH="curl -f -L -O -C -"
 elif test "`wget -V`"; then
-	FETCH="wget -c"
+    FETCH="wget -c"
 else
-	echo "Could not find either curl or wget, please install either one to continue"
-	exit 1
+    echo "Could not find either curl or wget, please install either one to continue"
+    exit 1
 fi
 
-if test "`parallel -V`"; then
-	PARALLEL="TRUE"
+if test "`aria2c -v`"; then
+    ARIA2="TRUE"
 else
-	PARALLEL="FALSE"
+    ARIA2="FALSE"
 fi
 
-if [[ "$PARALLEL" == "FALSE" ]]; then
-	$FETCH https://ftp.gnu.org/gnu/gnu-keyring.gpg
+if [[ "$ARIA2" == "FALSE" ]]; then
+    $FETCH https://ftp.gnu.org/gnu/gnu-keyring.gpg
 
-	$FETCH https://ftp.gnu.org/gnu/binutils/binutils-${BINUTILSVER}${BINUTILSREV}.tar.bz2.sig
-	$FETCH https://ftp.gnu.org/gnu/gcc/gcc-${GCCVER}${GCCREV}/gcc-${GCCVER}${GCCREV}.tar.gz.sig
+    $FETCH https://ftp.gnu.org/gnu/binutils/binutils-${BINUTILSVER}${BINUTILSREV}.tar.bz2.sig
+    $FETCH https://ftp.gnu.org/gnu/gcc/gcc-${GCCVER}${GCCREV}/gcc-${GCCVER}${GCCREV}.tar.xz.sig
 
-	$FETCH https://ftp.gnu.org/gnu/binutils/binutils-${BINUTILSVER}${BINUTILSREV}.tar.bz2
-	$FETCH https://ftp.gnu.org/gnu/gcc/gcc-${GCCVER}${GCCREV}/gcc-${GCCVER}${GCCREV}.tar.gz
-	$FETCH https://sourceware.org/pub/newlib/newlib-${NEWLIBVER}${NEWLIBREV}.tar.gz
-	if [ -n "${MPCVER}" ]; then
-		$FETCH https://ftp.gnu.org/gnu/mpc/mpc-${MPCVER}${MPCREV}.tar.gz.sig
-		$FETCH https://ftp.gnu.org/gnu/mpc/mpc-${MPCVER}${MPCREV}.tar.gz
-	fi
-	if [ -n "${MPFRVER}" ]; then
-		$FETCH https://ftp.gnu.org/gnu/mpfr/mpfr-${MPFRVER}${MPFRREV}.tar.bz2.sig
-		$FETCH https://ftp.gnu.org/gnu/mpfr/mpfr-${MPFRVER}${MPFRREV}.tar.bz2
-	fi
-	if [ -n "${GMPVER}" ]; then
-		$FETCH https://gmplib.org/download/gmp/gmp-${GMPVER}${GMPREV}.tar.bz2.sig
-		$FETCH https://gmplib.org/download/gmp/gmp-${GMPVER}${GMPREV}.tar.bz2
-	fi
+    $FETCH https://ftp.gnu.org/gnu/binutils/binutils-${BINUTILSVER}${BINUTILSREV}.tar.bz2
+    $FETCH https://ftp.gnu.org/gnu/gcc/gcc-${GCCVER}${GCCREV}/gcc-${GCCVER}${GCCREV}.tar.xz
+    $FETCH https://sourceware.org/pub/newlib/newlib-${NEWLIBVER}${NEWLIBREV}.tar.gz
+    if [ -n "${MPCVER}" ]; then
+        $FETCH https://ftp.gnu.org/gnu/mpc/mpc-${MPCVER}${MPCREV}.tar.gz.sig
+        $FETCH https://ftp.gnu.org/gnu/mpc/mpc-${MPCVER}${MPCREV}.tar.gz
+    fi
+    if [ -n "${MPFRVER}" ]; then
+        $FETCH https://ftp.gnu.org/gnu/mpfr/mpfr-${MPFRVER}${MPFRREV}.tar.bz2.sig
+        $FETCH https://ftp.gnu.org/gnu/mpfr/mpfr-${MPFRVER}${MPFRREV}.tar.bz2
+    fi
+    if [ -n "${GMPVER}" ]; then
+        $FETCH https://gmplib.org/download/gmp/gmp-${GMPVER}${GMPREV}.tar.bz2.sig
+        $FETCH https://gmplib.org/download/gmp/gmp-${GMPVER}${GMPREV}.tar.bz2
+    fi
 else
-	echo "https://ftp.gnu.org/gnu/gnu-keyring.gpg" > downloadlist.txt
-	echo "https://ftp.gnu.org/gnu/binutils/binutils-${BINUTILSVER}${BINUTILSREV}.tar.bz2.sig" >> downloadlist.txt
-	echo "https://ftp.gnu.org/gnu/gcc/gcc-${GCCVER}${GCCREV}/gcc-${GCCVER}${GCCREV}.tar.bz2.sig" >> downloadlist.txt
-	echo "https://ftp.gnu.org/gnu/binutils/binutils-${BINUTILSVER}${BINUTILSREV}.tar.bz2" >> downloadlist.txt
-	echo "https://ftp.gnu.org/gnu/gcc/gcc-${GCCVER}${GCCREV}/gcc-${GCCVER}${GCCREV}.tar.gz" >> downloadlist.txt
-	echo "ftp://sourceware.org/pub/newlib/newlib-${NEWLIBVER}${NEWLIBREV}.tar.gz" >> downloadlist.txt
+    echo "https://ftp.gnu.org/gnu/gnu-keyring.gpg" > downloadlist.txt
+    echo "https://ftp.gnu.org/gnu/binutils/binutils-${BINUTILSVER}${BINUTILSREV}.tar.bz2.sig" >> downloadlist.txt
+    echo "https://ftp.gnu.org/gnu/gcc/gcc-${GCCVER}${GCCREV}/gcc-${GCCVER}${GCCREV}.tar.xz.sig" >> downloadlist.txt
+    echo "https://ftp.gnu.org/gnu/binutils/binutils-${BINUTILSVER}${BINUTILSREV}.tar.bz2" >> downloadlist.txt
+    echo "https://ftp.gnu.org/gnu/gcc/gcc-${GCCVER}${GCCREV}/gcc-${GCCVER}${GCCREV}.tar.xz" >> downloadlist.txt
+    echo "ftp://sourceware.org/pub/newlib/newlib-${NEWLIBVER}${NEWLIBREV}.tar.gz" >> downloadlist.txt
 
-	if [ -n "${MPCVER}" ]; then
-		echo "https://ftp.gnu.org/gnu/mpc/mpc-${MPCVER}${MPCREV}.tar.gz.sig" >> downloadlist.txt
-		echo "https://ftp.gnu.org/gnu/mpc/mpc-${MPCVER}${MPCREV}.tar.gz" >> downloadlist.txt
-	fi
+    if [ -n "${MPCVER}" ]; then
+        echo "https://ftp.gnu.org/gnu/mpc/mpc-${MPCVER}${MPCREV}.tar.gz.sig" >> downloadlist.txt
+        echo "https://ftp.gnu.org/gnu/mpc/mpc-${MPCVER}${MPCREV}.tar.gz" >> downloadlist.txt
+    fi
 
-	if [ -n "${MPFRVER}" ]; then
-		echo "https://ftp.gnu.org/gnu/mpfr/mpfr-${MPFRVER}${MPFRREV}.tar.bz2.sig" >> downloadlist.txt
-		echo "https://ftp.gnu.org/gnu/mpfr/mpfr-${MPFRVER}${MPFRREV}.tar.bz2" >> downloadlist.txt
-	fi
+    if [ -n "${MPFRVER}" ]; then
+        echo "https://ftp.gnu.org/gnu/mpfr/mpfr-${MPFRVER}${MPFRREV}.tar.bz2.sig" >> downloadlist.txt
+        echo "https://ftp.gnu.org/gnu/mpfr/mpfr-${MPFRVER}${MPFRREV}.tar.bz2" >> downloadlist.txt
+    fi
 
-	if [ -n "${GMPVER}" ]; then
-		echo "https://gmplib.org/download/gmp/gmp-${GMPVER}${GMPREV}.tar.bz2.sig" >> downloadlist.txt
-		echo "https://gmplib.org/download/gmp/gmp-${GMPVER}${GMPREV}.tar.bz2" >> downloadlist.txt
-	fi
+    if [ -n "${GMPVER}" ]; then
+        echo "https://gmplib.org/download/gmp/gmp-${GMPVER}${GMPREV}.tar.bz2.sig" >> downloadlist.txt
+        echo "https://gmplib.org/download/gmp/gmp-${GMPVER}${GMPREV}.tar.bz2" >> downloadlist.txt
+    fi
 
-	cat downloadlist.txt | parallel -j 10 --progress --gnu $FETCH
+    aria2c -i downloadlist.txt
 fi
 
 # GPG return status
@@ -72,37 +72,37 @@ fi
 # 2 == no file
 gpg --verify --keyring ./gnu-keyring.gpg binutils-${BINUTILSVER}${BINUTILSREV}.tar.bz2.sig
 if [ $? -ne 0 ]; then
-	if [ $? -ne 0 ]; then
-		echo "Failed to verify GPG signature for binutils"
-		exit 1
-	fi
+    if [ $? -ne 0 ]; then
+        echo "Failed to verify GPG signature for binutils"
+        exit 1
+    fi
 fi
 
 gpg --verify --keyring ./gnu-keyring.gpg gcc-${GCCVER}${GCCREV}.tar.bz2.sig
 if [ $? -ne 0 ]; then
-	if [ $? -ne 0 ]; then
-		echo "Failed to verify GPG signautre for gcc"
-		exit 1
-	fi
+    if [ $? -ne 0 ]; then
+        echo "Failed to verify GPG signautre for gcc"
+        exit 1
+    fi
 fi
 
 if [ -n "${MPCVER}" ]; then
-	gpg --verify --keyring ./gnu-keyring.gpg mpc-${MPCVER}${MPCREV}.tar.gz.sig
-	if [ $? -ne 0 ]; then
-		if [ $? -ne 0 ]; then
-			echo "Failed to verify GPG signautre for mpc"
-			exit 1
-		fi
-	fi
+    gpg --verify --keyring ./gnu-keyring.gpg mpc-${MPCVER}${MPCREV}.tar.gz.sig
+    if [ $? -ne 0 ]; then
+        if [ $? -ne 0 ]; then
+            echo "Failed to verify GPG signautre for mpc"
+            exit 1
+        fi
+    fi
 fi
 
 if [ -n "${MPFRVER}" ]; then
-	gpg --verify --keyring ./gnu-keyring.gpg mpfr-${MPFRVER}${MPFRREV}.tar.bz2.sig 
-	if [ $? -ne 0 ]; then
-		if [ $? -ne 0 ]; then
-			echo "Failed to verify GPG signautre for mpfr"
-			exit 1
-		fi
-	fi
+    gpg --verify --keyring ./gnu-keyring.gpg mpfr-${MPFRVER}${MPFRREV}.tar.bz2.sig 
+    if [ $? -ne 0 ]; then
+        if [ $? -ne 0 ]; then
+            echo "Failed to verify GPG signautre for mpfr"
+            exit 1
+        fi
+    fi
 fi
 

--- a/extract-source.sh
+++ b/extract-source.sh
@@ -3,67 +3,67 @@
 echo "Extracting source files..."
 
 if [ ! -d $SRCDIR ]; then
-	mkdir -p $SRCDIR
+    mkdir -p $SRCDIR
 fi
 
 cd $SRCDIR
 
 if [ ! -d binutils-${BINUTILSVER} ]; then
-	tar xvjpf $DOWNLOADDIR/binutils-${BINUTILSVER}${BINUTILSREV}.tar.bz2
-	if [ $? -ne 0 ]; then
-		rm -rf binutils-${BINUTILSVER}
-		exit 1
-	fi
-	cd $SRCDIR
+    tar xvjpf $DOWNLOADDIR/binutils-${BINUTILSVER}${BINUTILSREV}.tar.bz2
+    if [ $? -ne 0 ]; then
+        rm -rf binutils-${BINUTILSVER}
+        exit 1
+    fi
+    cd $SRCDIR
 fi
 
 if [ ! -d gcc-${GCCVER} ]; then
-	tar xvzpf $DOWNLOADDIR/gcc-${GCCVER}${GCCREV}.tar.gz
-	if [ $? -ne 0 ]; then
-		rm -rf gcc-${GCCVER}
-		exit 1
-	fi
+    tar xvf $DOWNLOADDIR/gcc-${GCCVER}${GCCREV}.tar.xz
+    if [ $? -ne 0 ]; then
+        rm -rf gcc-${GCCVER}
+        exit 1
+    fi
 fi
 
 if [ ! -d newlib-${NEWLIBVER} ]; then
-	tar xvzpf $DOWNLOADDIR/newlib-${NEWLIBVER}${NEWLIBREV}.tar.gz
-	if [ $? -ne 0 ]; then
-		rm -rf newlib-${NEWLIBVER}
-		exit 1
-	fi
+    tar xvzpf $DOWNLOADDIR/newlib-${NEWLIBVER}${NEWLIBREV}.tar.gz
+    if [ $? -ne 0 ]; then
+        rm -rf newlib-${NEWLIBVER}
+        exit 1
+    fi
 fi
 
 if [ -n "${MPCVER}" ]; then
-	if [ ! -d mpc-${MPCVER} ]; then
-		tar xvpf $DOWNLOADDIR/mpc-${MPCVER}${MPCREV}.tar.gz
-		if [ $? -ne 0 ]; then
-			rm -rf mpc-${MPCVER}
-			exit 1
-		fi
-	fi
-	cp -rv mpc-${MPCVER} gcc-${GCCVER}/mpc
+    if [ ! -d mpc-${MPCVER} ]; then
+        tar xvpf $DOWNLOADDIR/mpc-${MPCVER}${MPCREV}.tar.gz
+        if [ $? -ne 0 ]; then
+            rm -rf mpc-${MPCVER}
+            exit 1
+        fi
+    fi
+    cp -rv mpc-${MPCVER} gcc-${GCCVER}/mpc
 fi
 
 if [ -n "${MPFRVER}" ]; then
-	if [ ! -d mpfr-${MPFRVER} ]; then
-		tar xvjpf $DOWNLOADDIR/mpfr-${MPFRVER}${MPFRREV}.tar.bz2
-		if [ $? -ne 0 ]; then
-			rm -rf mpfr-${MPFRVER}
-			exit 1
-		fi
-	fi
-	cp -rv mpfr-${MPFRVER} gcc-${GCCVER}/mpfr
+    if [ ! -d mpfr-${MPFRVER} ]; then
+        tar xvjpf $DOWNLOADDIR/mpfr-${MPFRVER}${MPFRREV}.tar.bz2
+        if [ $? -ne 0 ]; then
+            rm -rf mpfr-${MPFRVER}
+            exit 1
+        fi
+    fi
+    cp -rv mpfr-${MPFRVER} gcc-${GCCVER}/mpfr
 fi
 
 if [ -n "${GMPVER}" ]; then
-	if [ ! -d gmp-${GMPVER} ]; then
-		tar xvjpf $DOWNLOADDIR/gmp-${GMPVER}${GMPREV}.tar.bz2
-		if [ $? -ne 0 ]; then
-			rm -rf gmp-${GMPVER}
-			exit 1
-		fi
-	fi
-	cp -rv gmp-${GMPVER} gcc-${GCCVER}/gmp
+    if [ ! -d gmp-${GMPVER} ]; then
+        tar xvjpf $DOWNLOADDIR/gmp-${GMPVER}${GMPREV}.tar.bz2
+        if [ $? -ne 0 ]; then
+            rm -rf gmp-${GMPVER}
+            exit 1
+        fi
+    fi
+    cp -rv gmp-${GMPVER} gcc-${GCCVER}/gmp
 fi
 
 echo "Done"


### PR DESCRIPTION
Updates versions and replaces `parallel` with `aria2c`. I've never used `parallel` and it didn't want to work when I installed it anyway. 

This is tested and working using https://github.com/thekidsfromyesterday/homebrew-saturn-sdk-gcc-sh2 on Linux (Fedora 30) and OSX

Sorry about my linting changes. I can revert those if needed. 